### PR TITLE
Better Documentation: Period Endings

### DIFF
--- a/tgm-new-media-plugin.php
+++ b/tgm-new-media-plugin.php
@@ -60,7 +60,7 @@ class TGM_New_Media_Plugin {
      *
      * @since 1.0.0
      *
-     * @return null Return early if not on a page add/edit screen
+     * @return null Return early if not on a page add/edit screen.
      */
     public function assets() {
 
@@ -100,7 +100,7 @@ class TGM_New_Media_Plugin {
      *
      * @since 1.0.0
      *
-     * @param object $post Current post object data
+     * @param object $post Current post object data.
      */
     public function metabox( $post ) {
 


### PR DESCRIPTION
As per the [PHP documentation standards in the core handbook](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/), this commit helps make the documentation better by adding:
- Period endings for descriptions
